### PR TITLE
Prevent duplicate plugins

### DIFF
--- a/build/resolver.js
+++ b/build/resolver.js
@@ -76,5 +76,5 @@ exports.lookup = function() {
     return fs.readdirAsync(directory).filter(function(file) {
       return fs.existsSync(path.join(directory, file, 'package.json'));
     });
-  }).then(_.flatten);
+  }).then(_.flatten).then(_.uniq);
 };

--- a/lib/resolver.coffee
+++ b/lib/resolver.coffee
@@ -67,3 +67,4 @@ exports.lookup = ->
 			return fs.readdirAsync(directory).filter (file) ->
 				return fs.existsSync(path.join(directory, file, 'package.json'))
 		.then(_.flatten)
+		.then(_.uniq)


### PR DESCRIPTION
Currently, if the same plugin is found in several locations, the end
user risks attempting to load the plugin more than once, with major
consequences depending on the application.
